### PR TITLE
Refactor `get_wallpapers` function to use glob pattern for directory matching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,10 +67,17 @@ name = "dayshift"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "glob",
  "serde",
  "serde_json",
  "winapi",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "iana-time-zone"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 chrono = { version = "0.4.38", features = ["serde"] }
+glob = "0.3.1"
 serde = { version = "1.0.199", features = ["derive"] }
 serde_json = "1.0.116"
 winapi = { version = "0.3.9", features = ["winuser"] }

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -6,14 +6,24 @@
 pub fn get_wallpapers(path: &std::path::PathBuf) -> Vec<std::path::PathBuf> {
     let mut wallpapers = Vec::new();
 
-    // Read the directory and store the paths that match the criteria
-    let paths = std::fs::read_dir(path).expect("Failed to read directory");
-    for path in paths {
-        let path = path.unwrap().path();
-        // Check if the path matches the criteria
-        match matches_criteria(&path) {
-            Some(true) => wallpapers.push(path),
-            _ => continue,
+    // Define the glob pattern for the directory
+    let mut pattern = path.clone();
+    if !path.ends_with(".png") || !path.ends_with(".jpg") {
+        pattern.push("*");
+    }
+
+    // Iterate over the files in the directory
+    let pattern = pattern.to_str().unwrap();
+    for entry in glob::glob(pattern).unwrap() {
+        match entry {
+            Ok(path) => {
+                println!("Path: {:?}", path);
+                // Check if the path matches the criteria
+                if matches_criteria(&path).unwrap_or(false) {
+                    wallpapers.push(path);
+                }
+            }
+            Err(e) => eprintln!("Error: {}", e),
         }
     }
 


### PR DESCRIPTION
This pull request refactors the `get_wallpapers` function to use a glob pattern for directory matching instead of iterating over the files in the directory.