### PR TITLE
Add JSON schema and example for theme configuration

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+    "json.schemas": [
+        {
+            "fileMatch": [
+                "/examples/**/*.config.json"
+            ],
+            "url": "./schema/theme.config.json"
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ While you don't need to provide a configuration file, you can create a `dayshift
         "start": "08:00",
         "duration": 12,
         "path": "day/*.png",
-        "mode": "sequential"
+        "mode": "random"
     },
     {
         "start": "20:00",
@@ -46,6 +46,10 @@ You can create as many time-frames as you want!
 - `mode`: The mode to use when selecting wallpapers. The following modes are available:
   - `random`: Select a random wallpaper from the directory.
   - `sequential`: Select wallpapers in order from the directory.
+
+### Examples
+
+See the [examples](examples) directory for example configurations.
 
 ## 📄 License
 

--- a/examples/basic-sequential/theme.config.json
+++ b/examples/basic-sequential/theme.config.json
@@ -1,0 +1,7 @@
+[
+    {
+        "start": "08:00",
+        "duration": 12,
+        "selection": "sequential"
+    }
+]

--- a/examples/day-night-randomized/theme.config.json
+++ b/examples/day-night-randomized/theme.config.json
@@ -1,0 +1,14 @@
+[
+    {
+        "start": "06:00",
+        "duration": 12,
+        "path": "day/*.png",
+        "selection": "random"
+    },
+    {
+        "start": "18:00",
+        "duration": 12,
+        "path": "night/*.png",
+        "selection": "random"
+    }
+]

--- a/examples/day-night/theme.config.json
+++ b/examples/day-night/theme.config.json
@@ -1,0 +1,14 @@
+[
+    {
+        "start": "06:00",
+        "duration": 12,
+        "path": "day/*.png",
+        "selection": "sequential"
+    },
+    {
+        "start": "18:00",
+        "duration": 12,
+        "path": "night/*.png",
+        "selection": "sequential"
+    }
+]

--- a/schema/theme.config.json
+++ b/schema/theme.config.json
@@ -1,0 +1,28 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "array",
+    "items": {
+        "type": "object",
+        "properties": {
+            "start": {
+                "type": "string",
+                "pattern": "^([01]?[0-9]|2[0-3]):[0-5][0-9]$"
+            },
+            "duration": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 24
+            },
+            "selection": {
+                "type": "string",
+                "enum": [
+                    "random",
+                    "sequential"
+                ]
+            },
+            "path": {
+                "type": "string"
+            }
+        }
+    }
+}


### PR DESCRIPTION
This pull request adds a JSON schema and an example file for theme configuration. The JSON schema defines the structure and validation rules for the theme configuration file, while the example file demonstrates how to use the schema. This will help ensure that theme configuration files are properly formatted and adhere to the specified schema.

Fixes #6